### PR TITLE
Feat: account store errors

### DIFF
--- a/nuxt/layers/core/app/enums/error-category.ts
+++ b/nuxt/layers/core/app/enums/error-category.ts
@@ -1,0 +1,5 @@
+export enum ErrorCategory {
+  USER_ACCOUNTS = 'user-accounts',
+  ACCOUNT_LIST = 'account-list',
+  PENDING_APPROVAL_COUNT = 'pending-approval-count'
+}

--- a/nuxt/layers/core/app/enums/error-code.ts
+++ b/nuxt/layers/core/app/enums/error-code.ts
@@ -1,0 +1,3 @@
+export enum ErrorCode {
+
+}

--- a/nuxt/layers/core/app/interfaces/fetch-error.ts
+++ b/nuxt/layers/core/app/interfaces/fetch-error.ts
@@ -1,0 +1,7 @@
+export interface FetchError {
+  category: ErrorCategory,
+  detail?: string | string[],
+  message: string,
+  statusCode: number,
+  type?: ErrorCode
+}

--- a/nuxt/layers/core/app/interfaces/fetch-error.ts
+++ b/nuxt/layers/core/app/interfaces/fetch-error.ts
@@ -1,3 +1,5 @@
+import { ErrorCategory, ErrorCode } from '#imports'
+
 export interface FetchError {
   category: ErrorCategory,
   detail?: string | string[],

--- a/nuxt/layers/core/app/stores/connect-account.ts
+++ b/nuxt/layers/core/app/stores/connect-account.ts
@@ -73,6 +73,7 @@ export const useConnectAccountStore = defineStore('nuxt-core-connect-account-sto
       }
     } catch (e) {
       console.error('Error retrieving user accounts.', e)
+      return undefined
     }
   }
 
@@ -132,6 +133,7 @@ export const useConnectAccountStore = defineStore('nuxt-core-connect-account-sto
     currentAccountName,
     userAccounts,
     pendingApprovalCount,
+    errors,
     // updateAuthUserInfo,
     setAccountInfo,
     getUserAccounts,

--- a/nuxt/layers/core/app/stores/connect-account.ts
+++ b/nuxt/layers/core/app/stores/connect-account.ts
@@ -8,6 +8,7 @@ export const useConnectAccountStore = defineStore('nuxt-core-connect-account-sto
   const userAccounts = ref<Account[]>([])
   const currentAccountName = computed<string>(() => currentAccount.value?.label || '')
   const pendingApprovalCount = ref<number>(0)
+  const errors = ref<FetchError[]>([])
 
   // TODO: implement
   /** Get user information from AUTH */
@@ -54,6 +55,14 @@ export const useConnectAccountStore = defineStore('nuxt-core-connect-account-sto
       const response = await $fetch<UserSettings[]>(`${apiURL}/users/${keycloakGuid}/settings`, {
         headers: {
           Authorization: `Bearer ${token}`
+        },
+        onResponseError ({ response }) {
+          errors.value.push({
+            statusCode: response.status || 500,
+            message: response._data?.message || 'Error retrieving user accounts.',
+            detail: response._data.detail || '',
+            category: ErrorCategory.ACCOUNT_LIST
+          })
         }
       })
 
@@ -63,22 +72,18 @@ export const useConnectAccountStore = defineStore('nuxt-core-connect-account-sto
         return undefined
       }
     } catch (e) {
-      console.log(e)
+      console.error('Error retrieving user accounts.', e)
     }
   }
 
   /** Set the user account list and current account */
   async function setAccountInfo () {
-    try {
-      if (kcUser.value?.keycloakGuid) {
-        const response = await getUserAccounts(kcUser.value?.keycloakGuid)
-        if (response && response[0] !== undefined) {
-          userAccounts.value = response
-          currentAccount.value = response[0]
-        }
+    if (kcUser.value?.keycloakGuid) {
+      const response = await getUserAccounts(kcUser.value?.keycloakGuid)
+      if (response && response[0] !== undefined) {
+        userAccounts.value = response
+        currentAccount.value = response[0]
       }
-    } catch (e) {
-      console.log(e)
     }
   }
 
@@ -96,6 +101,14 @@ export const useConnectAccountStore = defineStore('nuxt-core-connect-account-sto
       const response = await $fetch<{ count: number }>(`${apiURL}/users/${keycloakGuid}/org/${accountId}/notifications`, {
         headers: {
           Authorization: `Bearer ${token}`
+        },
+        onResponseError ({ response }) {
+          errors.value.push({
+            statusCode: response.status || 500,
+            message: response._data.message || 'Error retrieving pending approvals.',
+            detail: response._data.detail || '',
+            category: ErrorCategory.PENDING_APPROVAL_COUNT
+          })
         }
       })
 
@@ -103,8 +116,7 @@ export const useConnectAccountStore = defineStore('nuxt-core-connect-account-sto
         pendingApprovalCount.value = response.count
       }
     } catch (e) {
-      console.error('Error retrieving pending approvals.')
-      console.error(e)
+      console.error('Error retrieving pending approvals.', e)
     }
   }
 
@@ -112,6 +124,7 @@ export const useConnectAccountStore = defineStore('nuxt-core-connect-account-sto
     currentAccount.value = {} as Account
     userAccounts.value = []
     pendingApprovalCount.value = 0
+    errors.value = []
   }
 
   return {

--- a/nuxt/layers/core/app/stores/connect-account.ts
+++ b/nuxt/layers/core/app/stores/connect-account.ts
@@ -1,4 +1,4 @@
-// TODO: come up with and add error handling solution
+import { FetchError, ErrorCategory } from '#imports'
 /** Manages connect account data */
 export const useConnectAccountStore = defineStore('nuxt-core-connect-account-store', () => {
   const apiURL = useRuntimeConfig().public.authApiURL

--- a/nuxt/layers/core/app/tests/unit/stores/connect-account.test.ts
+++ b/nuxt/layers/core/app/tests/unit/stores/connect-account.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import { mockNuxtImport, registerEndpoint } from '@nuxt/test-utils/runtime'
 import { setActivePinia, createPinia } from 'pinia'
-import { AccountStatus, AccountType, useConnectAccountStore } from '#imports'
+import { AccountStatus, AccountType, useConnectAccountStore, ErrorCategory } from '#imports'
 
 mockNuxtImport('useRuntimeConfig', () => {
   return () => (

--- a/nuxt/layers/core/app/tests/unit/stores/connect-account.test.ts
+++ b/nuxt/layers/core/app/tests/unit/stores/connect-account.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
-import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { mockNuxtImport, registerEndpoint } from '@nuxt/test-utils/runtime'
 import { setActivePinia, createPinia } from 'pinia'
 import { AccountStatus, AccountType, useConnectAccountStore } from '#imports'
 
@@ -44,21 +44,39 @@ describe('Account Store Tests', () => {
     expect(accountStore.userAccounts).toEqual([])
     expect(accountStore.currentAccountName).toEqual('')
     expect(accountStore.pendingApprovalCount).toEqual(0)
+    expect(accountStore.errors).toEqual([])
   })
 
-  it('fetches and filters userAccounts', async () => {
-    const _fetch = vi.fn().mockResolvedValue([
-      { type: 'ACCOUNT', id: '1', accountType: 'PREMIUM', accountStatus: 'ACTIVE', label: 'Account 1', urlpath: '/account-1', urlorigin: 'https://example.com' },
-      { type: 'other', id: '2', accountType: 'BASIC', accountStatus: 'INACTIVE', label: 'Account 2', urlpath: '/account-2', urlorigin: 'https://example.com' },
-      { type: 'ACCOUNT', id: '3', accountType: 'PREMIUM', accountStatus: 'ACTIVE', label: 'Account 3', urlpath: '/account-3', urlorigin: 'https://example.com' }
-    ])
-    vi.stubGlobal('$fetch', _fetch)
-    const accountStore = useConnectAccountStore()
-    // get user accounts
-    const accounts = await accountStore.getUserAccounts('123')
-    // assert
-    expect(_fetch).toBeCalledTimes(1)
-    expect(accounts?.length).toEqual(2)
+  describe('getUserAccounts', () => {
+    it('fetches and filters userAccounts', async () => {
+      const _fetch = vi.fn().mockResolvedValue([
+        { type: 'ACCOUNT', id: '1', accountType: 'PREMIUM', accountStatus: 'ACTIVE', label: 'Account 1', urlpath: '/account-1', urlorigin: 'https://example.com' },
+        { type: 'other', id: '2', accountType: 'BASIC', accountStatus: 'INACTIVE', label: 'Account 2', urlpath: '/account-2', urlorigin: 'https://example.com' },
+        { type: 'ACCOUNT', id: '3', accountType: 'PREMIUM', accountStatus: 'ACTIVE', label: 'Account 3', urlpath: '/account-3', urlorigin: 'https://example.com' }
+      ])
+      vi.stubGlobal('$fetch', _fetch)
+      const accountStore = useConnectAccountStore()
+      // get user accounts
+      const accounts = await accountStore.getUserAccounts('123')
+      // assert
+      expect(_fetch).toBeCalledTimes(1)
+      expect(accounts?.length).toEqual(2)
+    })
+
+    it('handles errors when fetching userAccounts', async () => {
+      registerEndpoint('https://auth.example.com//users/123/settings', () => { throw new Error('some-error') })
+
+      const accountStore = useConnectAccountStore()
+
+      await accountStore.getUserAccounts('123')
+      expect(accountStore.errors.length).toBeGreaterThanOrEqual(1)
+      expect(accountStore.errors[0]).toEqual({
+        statusCode: 500,
+        message: 'Error retrieving user accounts.',
+        detail: '',
+        category: ErrorCategory.ACCOUNT_LIST
+      })
+    })
   })
 
   it('sets account info', async () => {
@@ -77,16 +95,33 @@ describe('Account Store Tests', () => {
     expect(accountStore.currentAccount.label).toEqual('Account 1')
   })
 
-  it('getPendingApprovalCount', async () => {
-    const _fetch = vi.fn().mockResolvedValue({ count: 3 })
-    vi.stubGlobal('$fetch', _fetch)
-    const accountStore = useConnectAccountStore()
+  describe('getPendingApprovalAccount', () => {
+    it('getPendingApprovalCount', async () => {
+      const _fetch = vi.fn().mockResolvedValue({ count: 3 })
+      vi.stubGlobal('$fetch', _fetch)
+      const accountStore = useConnectAccountStore()
 
-    // set account info
-    await accountStore.getPendingApprovalCount(1, '1')
-    // assert
-    expect(_fetch).toBeCalledTimes(1)
-    expect(accountStore.pendingApprovalCount).toEqual(3)
+      // set account info
+      await accountStore.getPendingApprovalCount(1, '1')
+      // assert
+      expect(_fetch).toBeCalledTimes(1)
+      expect(accountStore.pendingApprovalCount).toEqual(3)
+    })
+
+    it('handles errors when fetching userAccounts', async () => {
+      registerEndpoint('https://auth.example.com//users/456/org/1/notifications', () => { throw new Error('some-error') })
+
+      const accountStore = useConnectAccountStore()
+
+      await accountStore.getPendingApprovalCount(1, '456')
+      expect(accountStore.errors.length).toBeGreaterThanOrEqual(1)
+      expect(accountStore.errors[0]).toEqual({
+        statusCode: 500,
+        message: 'Error retrieving pending approvals.',
+        detail: '',
+        category: ErrorCategory.PENDING_APPROVAL_COUNT
+      })
+    })
   })
 
   it('can switch the current account', () => {
@@ -115,11 +150,18 @@ describe('Account Store Tests', () => {
     accountStore.userAccounts = accounts
     accountStore.currentAccount = accounts[0]!
     accountStore.pendingApprovalCount = 4
+    accountStore.errors.push({
+      statusCode: 500,
+      message: 'Test Error',
+      detail: 'Detailed error info',
+      category: ErrorCategory.ACCOUNT_LIST
+    })
 
     // check store has values
     expect(accountStore.userAccounts.length).toEqual(3)
     expect(accountStore.currentAccount).not.toEqual({})
     expect(accountStore.pendingApprovalCount).toEqual(4)
+    expect(accountStore.errors.length).toEqual(1)
 
     // reset store
     accountStore.$reset()
@@ -127,5 +169,6 @@ describe('Account Store Tests', () => {
     expect(accountStore.userAccounts.length).toEqual(0)
     expect(accountStore.currentAccount).toEqual({})
     expect(accountStore.pendingApprovalCount).toEqual(0)
+    expect(accountStore.errors.length).toEqual(0)
   })
 })


### PR DESCRIPTION
issue: bcGov/entity#22507
Partial: bcGov/entity#22279

- add errors array to account store
- capture errors in 'onResponseError' from $fetch
- test changes