### PR TITLE
Manage User Session Expiry

### DIFF
--- a/nuxt/layers/core/.playground/app/pages/index.vue
+++ b/nuxt/layers/core/.playground/app/pages/index.vue
@@ -29,7 +29,7 @@ async function asyncFunction() {
 
 definePageMeta({
   onAccountChange: (newAccount, oldAccount) => manageAccountChange(newAccount, oldAccount),
-  sessionExpiredFn: () => console.log('session expired route meta'), // overwrite session expiry functionality
+  // sessionExpiredFn: () => console.log('session expired route meta'), // overwrite session expiry functionality
   // onBeforeSessionExpired: async () => await asyncFunction() // do something before session is expired using the default functionality
 })
 

--- a/nuxt/layers/core/.playground/app/pages/index.vue
+++ b/nuxt/layers/core/.playground/app/pages/index.vue
@@ -20,9 +20,17 @@ const actions = [
   }
 ]
 
+async function asyncFunction() {
+  return new Promise<void>((resolve) => setTimeout(() => {
+    console.log("test async")
+    resolve()
+  }, 5000))
+}
+
 definePageMeta({
   onAccountChange: (newAccount, oldAccount) => manageAccountChange(newAccount, oldAccount),
-  onSessionExpired: () => console.log('session expired route meta')
+  // onSessionExpired: () => console.log('session expired route meta'), // overwrite session expiry functionality
+  onBeforeSessionExpired: async () => await asyncFunction() // do something before session is expired using the default functionality
 })
 
 setBreadcrumbs([

--- a/nuxt/layers/core/.playground/app/pages/index.vue
+++ b/nuxt/layers/core/.playground/app/pages/index.vue
@@ -21,7 +21,8 @@ const actions = [
 ]
 
 definePageMeta({
-  onAccountChange: (newAccount, oldAccount) => manageAccountChange(newAccount, oldAccount)
+  onAccountChange: (newAccount, oldAccount) => manageAccountChange(newAccount, oldAccount),
+  onSessionExpired: () => console.log('session expired route meta')
 })
 
 setBreadcrumbs([

--- a/nuxt/layers/core/.playground/app/pages/index.vue
+++ b/nuxt/layers/core/.playground/app/pages/index.vue
@@ -29,8 +29,8 @@ async function asyncFunction() {
 
 definePageMeta({
   onAccountChange: (newAccount, oldAccount) => manageAccountChange(newAccount, oldAccount),
-  // onSessionExpired: () => console.log('session expired route meta'), // overwrite session expiry functionality
-  onBeforeSessionExpired: async () => await asyncFunction() // do something before session is expired using the default functionality
+  sessionExpiredFn: () => console.log('session expired route meta'), // overwrite session expiry functionality
+  // onBeforeSessionExpired: async () => await asyncFunction() // do something before session is expired using the default functionality
 })
 
 setBreadcrumbs([

--- a/nuxt/layers/core/.playground/app/pages/test-2.vue
+++ b/nuxt/layers/core/.playground/app/pages/test-2.vue
@@ -9,9 +9,11 @@ setBreadcrumbs([
 definePageMeta({
   onAccountChange: (newAccount, oldAccount) => manageAccountChangeAbort(newAccount, oldAccount)
 })
+const user = ref(undefined)
 </script>
 <template>
   <div class="flex flex-col gap-8 border border-black px-2 py-8">
+    <p>{{ user.name }}</p>
     <h1>
       Testing 2 page
     </h1>

--- a/nuxt/layers/core/app/app.config.ts
+++ b/nuxt/layers/core/app/app.config.ts
@@ -30,6 +30,11 @@ export default defineAppConfig({
             401: '/'
           }
         }
+      },
+      keycloak: {
+        refreshIntervalTimeout: 30000, // token will schedule refresh check every 30 seconds
+        minValidity: 120, // token min validity 120 seconds
+        idleTimeout: 30 * 60000 // user inactivity triggered after 30 minutes
       }
     }
   },

--- a/nuxt/layers/core/app/app.config.ts
+++ b/nuxt/layers/core/app/app.config.ts
@@ -30,11 +30,6 @@ export default defineAppConfig({
             401: '/'
           }
         }
-      },
-      keycloak: {
-        refreshIntervalTimeout: 30000, // token will schedule refresh check every 30 seconds
-        minValidity: 120, // token min validity 120 seconds
-        idleTimeout: 30 * 60000 // user inactivity triggered after 30 minutes
       }
     }
   },

--- a/nuxt/layers/core/app/components/Connect/Modal/Session/Expiring.vue
+++ b/nuxt/layers/core/app/components/Connect/Modal/Session/Expiring.vue
@@ -17,8 +17,6 @@ setInterval(() => {
 const ariaCountdownText = computed(() => {
   if (timeRemaining.value === 30) { // trigger aria alert when 30 seconds remain
     return t('ConnectModalSessionExpiring.content', { count: timeRemaining.value })
-  } else if (timeRemaining.value === 10) { // trigger aria alert when 10 seconds remain
-    return t('ConnectModalSessionExpiring.content', { count: timeRemaining.value })
   } else if (timeRemaining.value === 2) { // trigger aria alert when session expires
     return t('ConnectModalSessionExpiring.sessionExpired')
   } else {
@@ -34,7 +32,7 @@ onMounted(async () => {
   // allow any keypress to close the modal
   window.addEventListener('keydown', closeModal)
 
-  // cant add directly to UModal so using this instead
+  // cant add these props directly to UModal so using this as workaround
   await nextTick()
   const el = document.getElementById('session-expired-dialog')
   if (el) {
@@ -43,6 +41,7 @@ onMounted(async () => {
   }
 })
 onUnmounted(() => {
+  // cleanup
   window.removeEventListener('keydown', closeModal)
 })
 </script>

--- a/nuxt/layers/core/app/components/Connect/Modal/Session/Expiring.vue
+++ b/nuxt/layers/core/app/components/Connect/Modal/Session/Expiring.vue
@@ -30,9 +30,17 @@ function closeModal () {
   modalModel.value = false
 }
 
-// allow any keypress to close the modal
-onMounted(() => {
+onMounted(async () => {
+  // allow any keypress to close the modal
   window.addEventListener('keydown', closeModal)
+
+  // cant add directly to UModal so using this instead
+  await nextTick()
+  const el = document.getElementById('session-expired-dialog')
+  if (el) {
+    el.setAttribute('aria-labelledby', 'session-expired-dialog-title')
+    el.setAttribute('aria-describedby', 'session-expired-dialog-description')
+  }
 })
 onUnmounted(() => {
   window.removeEventListener('keydown', closeModal)
@@ -40,9 +48,11 @@ onUnmounted(() => {
 </script>
 <template>
   <UModal
+    id="session-expired-dialog"
     v-model="modalModel"
     overlay
     :ui="{ width: 'w-full sm:max-w-lg md:min-w-min' }"
+    role="alertdialog"
     @after-leave="$emit('afterLeave')"
   >
     <UCard
@@ -67,11 +77,19 @@ onUnmounted(() => {
       }"
     >
       <template #header>
-        <span class="text-xl font-semibold text-bcGovColor-darkGray">{{ $t('ConnectModalSessionExpiring.title') }}</span>
+        <div role="alert">
+          <h2
+            id="session-expired-dialog-title"
+            class="text-xl font-semibold text-bcGovColor-darkGray"
+          >
+            {{ $t('ConnectModalSessionExpiring.title') }}
+          </h2>
+        </div>
       </template>
 
       <div>
         <ConnectI18nHelper
+          id="session-expired-dialog-description"
           translation-path="ConnectModalSessionExpiring.content"
           :count="timeRemaining"
         />

--- a/nuxt/layers/core/app/components/Connect/Modal/Session/Expiring.vue
+++ b/nuxt/layers/core/app/components/Connect/Modal/Session/Expiring.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+const modalModel = defineModel({ type: Boolean, default: false })
+const isSmallScreen = useMediaQuery('(max-width: 640px)')
+const modalTimeout = useRuntimeConfig().public.sessionExpiredModalTimeout
+const { t } = useI18n()
+
+defineEmits<{
+  afterLeave: [void]
+}>()
+
+const timeRemaining = ref(toValue((modalTimeout as number) / 1000))
+setInterval(() => {
+  const value = timeRemaining.value - 1
+  timeRemaining.value = value < 0 ? 0 : value
+}, 1000)
+
+const ariaCountdownText = computed(() => {
+  if (timeRemaining.value % 10 === 0) {
+    return t('ConnectModalSessionExpiring.content', { count: timeRemaining.value })
+  } else if (timeRemaining.value === 2) {
+    return t('ConnectModalSessionExpiring.sessionExpired')
+  } else {
+    return ''
+  }
+})
+
+function closeModal () {
+  modalModel.value = false
+}
+
+// allow any keypress to close the modal
+onMounted(() => {
+  window.addEventListener('keydown', closeModal)
+})
+onUnmounted(() => {
+  window.removeEventListener('keydown', closeModal)
+})
+</script>
+<template>
+  <UModal
+    v-model="modalModel"
+    overlay
+    :ui="{ width: 'w-full sm:max-w-lg md:min-w-min' }"
+    @after-leave="$emit('afterLeave')"
+  >
+    <UCard
+      :ui="{
+        divide: '',
+        rounded: 'rounded',
+        body: {
+          base: '',
+          background: '',
+          padding: 'px-6 py-0 sm:px-10 sm:py-0'
+        },
+        header: {
+          base: '',
+          background: '',
+          padding: 'px-6 py-6 sm:px-10 sm:py-10'
+        },
+        footer: {
+          base: '',
+          background: '',
+          padding: 'px-6 py-6 sm:px-10 sm:py-10'
+        }
+      }"
+    >
+      <template #header>
+        <span class="text-xl font-semibold text-bcGovColor-darkGray">{{ $t('ConnectModalSessionExpiring.title') }}</span>
+      </template>
+
+      <div>
+        <ConnectI18nHelper
+          translation-path="ConnectModalSessionExpiring.content"
+          :count="timeRemaining"
+        />
+
+        <div role="alert">
+          <span class="sr-only">{{ ariaCountdownText }}</span>
+        </div>
+      </div>
+
+      <template #footer>
+        <div class="flex flex-wrap items-center justify-center gap-4">
+          <UButton
+            :block="isSmallScreen"
+            :label="$t('ConnectModalSessionExpiring.continueBtn.main')"
+            :aria-label="$t('ConnectModalSessionExpiring.continueBtn.aria')"
+            size="bcGov"
+            class="font-bold"
+            @click="modalModel = false"
+          />
+        </div>
+      </template>
+    </UCard>
+  </UModal>
+</template>

--- a/nuxt/layers/core/app/components/Connect/Modal/Session/Expiring.vue
+++ b/nuxt/layers/core/app/components/Connect/Modal/Session/Expiring.vue
@@ -15,9 +15,11 @@ setInterval(() => {
 }, 1000)
 
 const ariaCountdownText = computed(() => {
-  if (timeRemaining.value % 10 === 0) {
+  if (timeRemaining.value === 30) { // trigger aria alert when 30 seconds remain
     return t('ConnectModalSessionExpiring.content', { count: timeRemaining.value })
-  } else if (timeRemaining.value === 2) {
+  } else if (timeRemaining.value === 10) { // trigger aria alert when 10 seconds remain
+    return t('ConnectModalSessionExpiring.content', { count: timeRemaining.value })
+  } else if (timeRemaining.value === 2) { // trigger aria alert when session expires
     return t('ConnectModalSessionExpiring.sessionExpired')
   } else {
     return ''

--- a/nuxt/layers/core/app/composables/useConnectModals.ts
+++ b/nuxt/layers/core/app/composables/useConnectModals.ts
@@ -1,0 +1,25 @@
+// https://ui.nuxt.com/components/modal#control-programmatically
+import {
+  ConnectModalSessionExpiring
+} from '#components'
+
+export const useConnectModals = () => {
+  const modal = useModal()
+
+  function openSessionExpiringModal (cb: () => void) {
+    modal.open(ConnectModalSessionExpiring, {
+      onAfterLeave () {
+        cb()
+      }
+    })
+  }
+
+  function close () {
+    modal.close()
+  }
+
+  return {
+    openSessionExpiringModal,
+    close
+  }
+}

--- a/nuxt/layers/core/app/enums/connect-storage-keys.ts
+++ b/nuxt/layers/core/app/enums/connect-storage-keys.ts
@@ -1,4 +1,5 @@
 export enum ConnectStorageKeys {
   LOGIN_REDIRECT_URL = 'sbc-connect-login-redirect-url',
   LOGOUT_REDIRECT_URL = 'sbc-connect-logout-redirect-url',
+  CONNECT_SESSION_EXPIRED = 'connect-session-expired'
 }

--- a/nuxt/layers/core/app/error.vue
+++ b/nuxt/layers/core/app/error.vue
@@ -17,6 +17,25 @@ useRoute().meta.hideBreadcrumbs = true
 useHead({
   title: errorKey === 404 ? t('ConnectPage.error.404.title') : t('ConnectPage.error.unknown.title')
 })
+
+const manageError = async () => {
+  clearError()
+  await navigateTo(localePath('/'))
+}
+
+const errorObj = {
+  name: props.error?.name || '',
+  cause: props.error?.cause || '',
+  message: props.error?.message || '',
+  statusCode: props.error?.statusCode || '',
+  statusMessage: props.error?.statusMessage || '',
+  stack: props.error?.stack || '',
+  data: props.error?.data || ''
+}
+
+onMounted(() => {
+  console.error('Nuxt Application Error: ', errorObj)
+})
 </script>
 <template>
   <NuxtLayout name="default">
@@ -25,11 +44,12 @@ useHead({
         {{ $t(`ConnectPage.error.${errorKey}.h1`) }}
       </h1>
       <p>{{ $t(`ConnectPage.error.${errorKey}.content`) }}</p>
+      <pre>{{ errorObj }}</pre>
       <UButton
         :label="$t('btn.goHome')"
         icon="i-mdi-home"
         size="bcGov"
-        :to="localePath('/')"
+        @click="manageError"
       />
     </div>
   </NuxtLayout>

--- a/nuxt/layers/core/app/error.vue
+++ b/nuxt/layers/core/app/error.vue
@@ -44,7 +44,6 @@ onMounted(() => {
         {{ $t(`ConnectPage.error.${errorKey}.h1`) }}
       </h1>
       <p>{{ $t(`ConnectPage.error.${errorKey}.content`) }}</p>
-      <pre>{{ errorObj }}</pre>
       <UButton
         :label="$t('btn.goHome')"
         icon="i-mdi-home"

--- a/nuxt/layers/core/app/error.vue
+++ b/nuxt/layers/core/app/error.vue
@@ -18,11 +18,6 @@ useHead({
   title: errorKey === 404 ? t('ConnectPage.error.404.title') : t('ConnectPage.error.unknown.title')
 })
 
-const manageError = async () => {
-  clearError()
-  await navigateTo(localePath('/'))
-}
-
 const errorObj = {
   name: props.error?.name || '',
   cause: props.error?.cause || '',
@@ -48,7 +43,7 @@ onMounted(() => {
         :label="$t('btn.goHome')"
         icon="i-mdi-home"
         size="bcGov"
-        @click="manageError"
+        :to="localePath('/')"
       />
     </div>
   </NuxtLayout>

--- a/nuxt/layers/core/app/locales/en-CA.ts
+++ b/nuxt/layers/core/app/locales/en-CA.ts
@@ -76,6 +76,15 @@ export default {
       }
     }
   },
+  ConnectModalSessionExpiring: {
+    title: 'Session Expiring Soon',
+    content: 'Your session is about to expire due to inactivity. You will be logged out in {boldStart}0{boldEnd} seconds. Press any key to continue. | Your session is about to expire due to inactivity. You will be logged out in {boldStart}1{boldEnd} second. Press any key to continue. | Your session is about to expire due to inactivity. You will be logged out in {boldStart}{count}{boldEnd} seconds. Press any key to continue.',
+    sessionExpired: 'Session Expired',
+    continueBtn: {
+      main: 'Continue Session',
+      aria: 'Your session is about to expire, press any key to continue.'
+    }
+  },
   test: {
     i18nBold: {
       strong: 'This should have {boldStart} bold {boldEnd} text',

--- a/nuxt/layers/core/app/locales/en-CA.ts
+++ b/nuxt/layers/core/app/locales/en-CA.ts
@@ -78,11 +78,11 @@ export default {
   },
   ConnectModalSessionExpiring: {
     title: 'Session Expiring Soon',
-    content: 'Your session is about to expire due to inactivity. You will be logged out in {boldStart}0{boldEnd} seconds. Press any key to continue. | Your session is about to expire due to inactivity. You will be logged out in {boldStart}1{boldEnd} second. Press any key to continue. | Your session is about to expire due to inactivity. You will be logged out in {boldStart}{count}{boldEnd} seconds. Press any key to continue.',
+    content: 'Your session is about to expire due to inactivity. You will be logged out in {boldStart}0{boldEnd} seconds. Press any key to continue your session. | Your session is about to expire due to inactivity. You will be logged out in {boldStart}1{boldEnd} second. Press any key to continue your session. | Your session is about to expire due to inactivity. You will be logged out in {boldStart}{count}{boldEnd} seconds. Press any key to continue your session.',
     sessionExpired: 'Session Expired',
     continueBtn: {
       main: 'Continue Session',
-      aria: 'Your session is about to expire, press any key to continue.'
+      aria: 'Your session is about to expire, press any key to continue your session.'
     }
   },
   test: {

--- a/nuxt/layers/core/app/locales/fr-CA.ts
+++ b/nuxt/layers/core/app/locales/fr-CA.ts
@@ -75,5 +75,14 @@ export default {
         content: 'Une erreur inconnue s’est produite, veuillez actualiser la page ou réessayer plus tard.'
       }
     }
+  },
+  ConnectModalSessionExpiring: {
+    title: "Session Sur Le Point D'Expirer",
+    content: "Votre session est sur le point d'expirer en raison d'inactivité. Vous serez déconnecté dans {boldStart}0{boldEnd} secondes. Appuyez sur n'importe quelle touche pour continuer. | Votre session est sur le point d'expirer en raison d'inactivité. Vous serez déconnecté dans {boldStart}1{boldEnd} seconde. Appuyez sur n'importe quelle touche pour continuer. | Votre session est sur le point d'expirer en raison d'inactivité. Vous serez déconnecté dans {boldStart}{count}{boldEnd} secondes. Appuyez sur n'importe quelle touche pour continuer.",
+    sessionExpired: 'Session Expirée',
+    continueBtn: {
+      main: 'Continuer la Session',
+      aria: "Votre session est sur le point d'expirer, appuyez sur n'importe quelle touche pour continuer."
+    }
   }
 }

--- a/nuxt/layers/core/app/locales/fr-CA.ts
+++ b/nuxt/layers/core/app/locales/fr-CA.ts
@@ -78,11 +78,11 @@ export default {
   },
   ConnectModalSessionExpiring: {
     title: "Session Sur Le Point D'Expirer",
-    content: "Votre session est sur le point d'expirer en raison d'inactivité. Vous serez déconnecté dans {boldStart}0{boldEnd} secondes. Appuyez sur n'importe quelle touche pour continuer. | Votre session est sur le point d'expirer en raison d'inactivité. Vous serez déconnecté dans {boldStart}1{boldEnd} seconde. Appuyez sur n'importe quelle touche pour continuer. | Votre session est sur le point d'expirer en raison d'inactivité. Vous serez déconnecté dans {boldStart}{count}{boldEnd} secondes. Appuyez sur n'importe quelle touche pour continuer.",
+    content: "Votre session est sur le point d'expirer en raison d'inactivité. Vous serez déconnecté dans {boldStart}0{boldEnd} secondes. Appuyez sur n’importe quelle touche pour continuer votre session. | Votre session est sur le point d'expirer en raison d'inactivité. Vous serez déconnecté dans {boldStart}1{boldEnd} seconde. Appuyez sur n’importe quelle touche pour continuer votre session. | Votre session est sur le point d'expirer en raison d'inactivité. Vous serez déconnecté dans {boldStart}{count}{boldEnd} secondes. Appuyez sur n’importe quelle touche pour continuer votre session.",
     sessionExpired: 'Session Expirée',
     continueBtn: {
       main: 'Continuer la Session',
-      aria: "Votre session est sur le point d'expirer, appuyez sur n'importe quelle touche pour continuer."
+      aria: "Votre session est sur le point d'expirer, appuyez sur n'importe quelle touche pour continuer votre session."
     }
   }
 }

--- a/nuxt/layers/core/app/plugins/01.keycloak.client.ts
+++ b/nuxt/layers/core/app/plugins/01.keycloak.client.ts
@@ -55,8 +55,6 @@ export default defineNuxtPlugin(async () => {
         await result
       }
     } else {
-      useConnectModals().openSessionExpiringModal(resetSessionTimeout)
-
       // cleanup modal timeout if exists
       resetSessionTimeout()
 
@@ -71,6 +69,9 @@ export default defineNuxtPlugin(async () => {
         sessionStorage.setItem(ConnectStorageKeys.CONNECT_SESSION_EXPIRED, 'true')
         keycloak.logout()
       }, modalTimeout)
+
+      // open modal and pass resetSessionTimeout as a callback to clear the timeout if the user closes the modal with click/keyboard event
+      useConnectModals().openSessionExpiringModal(resetSessionTimeout)
     }
   }
 

--- a/nuxt/layers/core/app/plugins/01.keycloak.client.ts
+++ b/nuxt/layers/core/app/plugins/01.keycloak.client.ts
@@ -95,6 +95,7 @@ export default defineNuxtPlugin(async () => {
       }
       // re-schedule only if the user remains active and authenticated
       if (keycloak.authenticated && !idle.value) {
+        console.info('Starting token refresh schedule.')
         scheduleRefreshToken()
       }
     }, refreshIntervalTimeout)

--- a/nuxt/layers/core/app/plugins/01.keycloak.client.ts
+++ b/nuxt/layers/core/app/plugins/01.keycloak.client.ts
@@ -1,13 +1,19 @@
 import Keycloak from 'keycloak-js'
 
 export default defineNuxtPlugin(async () => {
-  const config = useRuntimeConfig()
+  const rtc = useRuntimeConfig().public
+  const kcConfig = useAppConfig().connect.core.keycloak
+
   // define new keycloak
   const keycloak = new Keycloak({
-    url: config.public.keycloakAuthUrl,
-    realm: config.public.keycloakRealm,
-    clientId: config.public.keycloakClientId
+    url: rtc.keycloakAuthUrl,
+    realm: rtc.keycloakRealm,
+    clientId: rtc.keycloakClientId
   })
+
+  const refreshIntervalTimeout = kcConfig.refreshIntervalTimeout
+  const minValidity = kcConfig.minValidity
+  const idleTimeout = kcConfig.idleTimeout
 
   try {
     // init keycloak instance
@@ -18,6 +24,69 @@ export default defineNuxtPlugin(async () => {
     })
   } catch (error) {
     console.error('Failed to initialize Keycloak adapter: ', error)
+  }
+
+  const route = useRoute()
+  const { idle } = useIdle(idleTimeout)
+
+  function sessionExpiredFn () {
+    if (route.meta.onSessionExpired) {
+      route.meta.onSessionExpired()
+    } else {
+      keycloak.logout()
+    }
+  }
+
+  function scheduleRefreshToken () {
+    setTimeout(async () => {
+      // do not refresh if user not authenticated or idle
+      if (!keycloak.authenticated || idle.value) {
+        console.info('User unauthenticated or inactive, stopping token refresh schedule.')
+        return
+      }
+
+      if (keycloak.isTokenExpired(minValidity)) {
+        console.info('Token set to expire soon. Refreshing token...')
+        try {
+          await keycloak.updateToken(minValidity)
+          console.info('Token updated.')
+        } catch (error) {
+          console.error('Error updating token:', error)
+          keycloak.logout() // log user out if token update fails
+        }
+      }
+      // re-schedule only if the user remains active and authenticated
+      if (keycloak.authenticated && !idle.value) {
+        scheduleRefreshToken()
+      }
+    }, refreshIntervalTimeout)
+  }
+
+  // Watch for changes in authentication and idle state
+  // When the user is authenticated and not idle, start the refresh schedule
+  // Execute session expiry handling if user authenticated and inactive
+  watch(
+    [() => keycloak.authenticated, () => idle.value],
+    ([isAuth, isIdle]) => {
+      if (isAuth && !isIdle) {
+        scheduleRefreshToken()
+      } else if (isAuth && isIdle) {
+        sessionExpiredFn()
+      }
+    },
+    { immediate: true }
+  )
+
+  // default behaviour when keycloak session expires
+  keycloak.onTokenExpired = async () => {
+    if (idle.value) {
+      sessionExpiredFn()
+    } else {
+      await keycloak.updateToken(minValidity).catch(() => {
+        console.error('Failed to refresh token on expiration; logging out.')
+        keycloak.logout() // refresh token failed or not available
+      })
+    }
   }
 
   return {

--- a/nuxt/layers/core/app/types/core-app-config.d.ts
+++ b/nuxt/layers/core/app/types/core-app-config.d.ts
@@ -35,11 +35,6 @@ declare module '@nuxt/schema' {
               401: string
             }
           }
-        },
-        keycloak?: {
-          refreshIntervalTimeout: number
-          minValidity: number
-          idleTimeout: number
         }
       }
     }
@@ -65,11 +60,6 @@ declare module 'nuxt/schema' {
               401: string
             }
           }
-        },
-        keycloak?: {
-          refreshIntervalTimeout: number
-          minValidity: number
-          idleTimeout: number
         }
       }
     }

--- a/nuxt/layers/core/app/types/core-app-config.d.ts
+++ b/nuxt/layers/core/app/types/core-app-config.d.ts
@@ -35,6 +35,41 @@ declare module '@nuxt/schema' {
               401: string
             }
           }
+        },
+        keycloak?: {
+          refreshIntervalTimeout: number
+          minValidity: number
+          idleTimeout: number
+        }
+      }
+    }
+  }
+}
+
+declare module 'nuxt/schema' {
+  interface AppConfig {
+    connect: {
+      core: {
+        login: LoginConfig,
+        header: {
+          options: HeaderOptions
+        },
+        plugin: {
+          authApi: {
+            errorRedirect: {
+              401: string
+            }
+          },
+          payApi: {
+            errorRedirect: {
+              401: string
+            }
+          }
+        },
+        keycloak?: {
+          refreshIntervalTimeout: number
+          minValidity: number
+          idleTimeout: number
         }
       }
     }

--- a/nuxt/layers/core/app/types/core-page-meta.d.ts
+++ b/nuxt/layers/core/app/types/core-page-meta.d.ts
@@ -3,6 +3,7 @@ declare module '#app' {
     breadcrumbs?: ConnectBreadcrumb[]
     hideBreadcrumbs?: boolean | undefined
     onAccountChange?: (newVal: Account, oldVal: Account) => boolean
+    onSessionExpired?: () => void
   }
 }
 

--- a/nuxt/layers/core/app/types/core-page-meta.d.ts
+++ b/nuxt/layers/core/app/types/core-page-meta.d.ts
@@ -3,8 +3,8 @@ declare module '#app' {
     breadcrumbs?: ConnectBreadcrumb[]
     hideBreadcrumbs?: boolean | undefined
     onAccountChange?: (newVal: Account, oldVal: Account) => boolean
-    onSessionExpired?: () => void
-    onBeforeSessionExpired?: () => void | Promise<void>
+    sessionExpiredFn?: () => void | Promise<void> // replace default functionality
+    onBeforeSessionExpired?: () => void | Promise<void> // do something right before the default session expiry is executed
   }
 }
 

--- a/nuxt/layers/core/app/types/core-page-meta.d.ts
+++ b/nuxt/layers/core/app/types/core-page-meta.d.ts
@@ -4,6 +4,7 @@ declare module '#app' {
     hideBreadcrumbs?: boolean | undefined
     onAccountChange?: (newVal: Account, oldVal: Account) => boolean
     onSessionExpired?: () => void
+    onBeforeSessionExpired?: () => void | Promise<void>
   }
 }
 

--- a/nuxt/layers/core/app/utils/setOnBeforeSessionExpired.ts
+++ b/nuxt/layers/core/app/utils/setOnBeforeSessionExpired.ts
@@ -1,5 +1,23 @@
 // cant use await inside definePageMeta so must use separate util to set page meta if await required
-export function setOnBeforeSessionExpired (cb: () => void | Promise<void>) {
+/**
+ * Sets the `onBeforeSessionExpired` callback for the current route.
+ *
+ * This function allows you to provide a callback (`cb`) that will be called before the session expires.
+ * The callback can either be synchronous (returning `void`) or asynchronous (returning a `Promise`).
+ * If the callback returns a promise, it will be awaited before continuing.
+ * If the callback is synchronous, it will execute immediately.
+ *
+ * @param {() => any | Promise<any>} cb - The callback function to execute before session expiry.
+ *
+ * @example
+ * setOnBeforeSessionExpired(() => {
+ *   // Do something before session expiry
+ * });
+ *
+ * @example
+ * setOnBeforeSessionExpired(() => submitApplication());
+ */
+export function setOnBeforeSessionExpired (cb: () => any | Promise<any>) {
   const route = useRoute()
   route.meta.onBeforeSessionExpired = async () => {
     try {

--- a/nuxt/layers/core/app/utils/setOnBeforeSessionExpired.ts
+++ b/nuxt/layers/core/app/utils/setOnBeforeSessionExpired.ts
@@ -1,0 +1,15 @@
+// cant use await inside definePageMeta so must use separate util to set page meta if await required
+export function setOnBeforeSessionExpired (cb: () => void | Promise<void>) {
+  const route = useRoute()
+  route.meta.onBeforeSessionExpired = async () => {
+    try {
+      const result = cb()
+
+      if (result instanceof Promise) {
+        await result
+      }
+    } catch (e) {
+      logFetchError(e, 'Error during session expiration handling')
+    }
+  }
+}

--- a/nuxt/layers/core/nuxt.config.ts
+++ b/nuxt/layers/core/nuxt.config.ts
@@ -89,7 +89,11 @@ export default defineNuxtConfig({
       environment: process.env.NUXT_ENVIRONMENT_HEADER || '',
       baseUrl: process.env.NUXT_BASE_URL,
       paymentPortalUrl: process.env.NUXT_PAYMENT_PORTAL_URL,
-      payApiURL: `${process.env.NUXT_PAY_API_URL}${process.env.NUXT_PAY_API_VERSION}`
+      payApiURL: `${process.env.NUXT_PAY_API_URL}${process.env.NUXT_PAY_API_VERSION}`,
+      tokenRefreshInterval: process.env.NUXT_KEYCLOAK_REFRESH_INTERVAL || 30000, // default 30 seconds
+      tokenMinValidity: process.env.NUXT_KEYCLOAK_MIN_TOKEN_VALIDITY || 120000, // default 2 mins
+      sessionIdleTimeout: process.env.NUXT_CONNECT_SESSION_INACTIVITY_TIMEOUT || 1800000, // default 30 mins
+      sessionExpiredModalTimeout: process.env.NUXT_CONNECT_SESSION_MODAL_TIMEOUT || 120000 // default 2 mins
     }
   },
 

--- a/nuxt/layers/core/nuxt.config.ts
+++ b/nuxt/layers/core/nuxt.config.ts
@@ -66,6 +66,11 @@ export default defineNuxtConfig({
   vite: {
     optimizeDeps: {
       include: ['keycloak-js', 'js-sha256']
+    },
+    server: {
+      watch: {
+        usePolling: true
+      }
     }
   },
 

--- a/nuxt/layers/core/package.json
+++ b/nuxt/layers/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daxiom/nuxt-core-layer-test",
   "type": "module",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "main": "./nuxt.config.ts",
   "scripts": {
     "dev": "nuxi dev .playground --port 3000",

--- a/nuxt/layers/core/package.json
+++ b/nuxt/layers/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daxiom/nuxt-core-layer-test",
   "type": "module",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "main": "./nuxt.config.ts",
   "scripts": {
     "dev": "nuxi dev .playground --port 3000",

--- a/nuxt/layers/core/package.json
+++ b/nuxt/layers/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daxiom/nuxt-core-layer-test",
   "type": "module",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "main": "./nuxt.config.ts",
   "scripts": {
     "dev": "nuxi dev .playground --port 3000",


### PR DESCRIPTION
Partial: [bcgov/#25445](https://github.com/bcgov/entity/issues/25445)

- Manage user session expiry through route meta or log user out by default
- also console.errored the error object in error.vue

### Considerations
- currently this will log the user out after 30 minutes by default, but that can be overwritten using the route meta. Should we have different default functionality?
- also I'm not sure how this will behave exactly as the default timeout and keycloak session are both 30 minutes, will need to test behaviour

Also thinking maybe we could have the default behaviour be the timeout modals and then if people wanted to have a custom implementation they could use the prebuilt modals and we could add a prop for the expiry function.


