### PR TITLE
25547 - Adding new products fee link to footer

### DIFF
--- a/nuxt/layers/core/app/components/Connect/Footer.vue
+++ b/nuxt/layers/core/app/components/Connect/Footer.vue
@@ -12,6 +12,11 @@ const links = [
     target: '_blank'
   },
   {
+    label: 'ConnectFooter.pricing',
+    to: 'https://www.bcregistry.gov.bc.ca/product-fees',
+    target: '_blank'
+  },
+  {
     label: 'ConnectFooter.disclaimer',
     to: 'https://www2.gov.bc.ca/gov/content/home/disclaimer',
     target: '_blank'

--- a/nuxt/layers/core/app/locales/en-CA.ts
+++ b/nuxt/layers/core/app/locales/en-CA.ts
@@ -38,6 +38,7 @@ export default {
     navLabel: 'Useful Links', // <nav> aria-label
     home: 'Home',
     releaseNotes: 'Release Notes',
+    pricing: 'Pricing',
     disclaimer: 'Disclaimer',
     privacy: 'Privacy',
     ally: 'Accessibility',

--- a/nuxt/layers/core/app/locales/fr-CA.ts
+++ b/nuxt/layers/core/app/locales/fr-CA.ts
@@ -38,6 +38,7 @@ export default {
     navLabel: 'Liens utiles', // <nav> aria-label
     home: 'Accueil',
     releaseNotes: 'Notes de Version',
+    pricing: 'Tarification',
     disclaimer: 'Clause de non-responsabilité',
     privacy: 'Confidentialité',
     ally: 'Accessibilité',

--- a/nuxt/layers/core/package.json
+++ b/nuxt/layers/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daxiom/nuxt-core-layer-test",
   "type": "module",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "main": "./nuxt.config.ts",
   "scripts": {
     "dev": "nuxi dev .playground --port 3000",


### PR DESCRIPTION
Adding a new link to the footer, to access the new products fee page (Pricing):

![image](https://github.com/user-attachments/assets/d3a1af36-c138-4b83-a7ec-3419b52aaf6f)
