### PR TITLE
28395 - Add in x-apikey header continued

### DIFF
--- a/nuxt/layers/core/app/plugins/auth-api.ts
+++ b/nuxt/layers/core/app/plugins/auth-api.ts
@@ -8,26 +8,8 @@ export default defineNuxtPlugin(() => {
   const api = $fetch.create({
     baseURL: authApiUrl,
     onRequest ({ options }) {
-      const headers = options.headers ||= {} as Headers
-      const bearerToken = `Bearer ${$keycloak.token}`
-      if (Array.isArray(headers)) {
-        headers.push(['Authorization', bearerToken])
-        if (authApiKey) {
-          headers.push(['x-apikey', authApiKey])
-        }
-      } else if (headers instanceof Headers) {
-        headers.set('Authorization', bearerToken)
-        if (authApiKey) {
-          headers.set('x-apikey', authApiKey)
-        }
-      } else {
-        // @ts-expect-error - 'Authorization' doesnt exist on type Headers
-        headers.Authorization = bearerToken
-        if (authApiKey) {
-          // @ts-expect-error - 'Authorization' doesnt exist on type Headers
-          headers['x-apikey'] = authApiKey
-        }
-      }
+      let headers = options.headers ||= {} as Headers
+      headers = addToHeaders(headers)
     },
     async onResponseError ({ response }) {
       if (response.status === 401) {
@@ -42,3 +24,26 @@ export default defineNuxtPlugin(() => {
     }
   }
 })
+
+export const addToHeaders = (headers: any) => {
+  const { $keycloak } = useNuxtApp()
+  const authApiKey = useRuntimeConfig().public.authApiKey
+  const bearerToken = `Bearer ${$keycloak.token}`
+  if (Array.isArray(headers)) {
+    headers.push(['Authorization', bearerToken])
+    if (authApiKey) {
+      headers.push(['x-apikey', authApiKey])
+    }
+  } else if (headers instanceof Headers) {
+    headers.set('Authorization', bearerToken)
+    if (authApiKey) {
+      headers.set('x-apikey', authApiKey)
+    }
+  } else {
+    headers.Authorization = bearerToken
+    if (authApiKey) {
+      headers['x-apikey'] = authApiKey
+    }
+  }
+  return headers
+}

--- a/nuxt/layers/core/app/stores/connect-account.ts
+++ b/nuxt/layers/core/app/stores/connect-account.ts
@@ -113,9 +113,9 @@ export const useConnectAccountStore = defineStore('connect-core-account-store', 
       // get from auth
       const authUserInfo = await getAuthUserProfile('@me')
       // firstName and lastName dont always exist it seems ?
-      if (authUserInfo.firstName !== undefined && authUserInfo.lastName !== undefined) {
-        userFirstName.value = authUserInfo.firstName
-        userLastName.value = authUserInfo.lastName
+      if (authUserInfo.firstname !== undefined && authUserInfo.lastname !== undefined) {
+        userFirstName.value = authUserInfo.firstname
+        userLastName.value = authUserInfo.lastname
       }
       return
     }

--- a/nuxt/layers/core/app/stores/connect-account.ts
+++ b/nuxt/layers/core/app/stores/connect-account.ts
@@ -1,4 +1,5 @@
 import { type ApiError, ErrorCategory } from '#imports'
+import { addToHeaders } from '~/plugins/auth-api'
 /** Manages connect account data */
 export const useConnectAccountStore = defineStore('connect-core-account-store', () => {
   const { $authApi, $keycloak } = useNuxtApp()
@@ -73,11 +74,8 @@ export const useConnectAccountStore = defineStore('connect-core-account-store', 
   async function getAuthUserProfile (identifier: string) {
     const authApiURL = rtc.authApiURL
     try {
-      await updateAuthUserInfo() // update user roles before fetching user info
       const response = await fetch(`${authApiURL}/users/${identifier}`, { // native fetch doesnt break app
-        headers: {
-          Authorization: `Bearer ${$keycloak.token}`
-        }
+        headers: addToHeaders({})
       })
       const data = await response.json()
       if (response.ok) {
@@ -227,6 +225,7 @@ export const useConnectAccountStore = defineStore('connect-core-account-store', 
 
   async function initAccountStore (): Promise<void> {
     await setAccountInfo() // load user accounts
+    await updateAuthUserInfo()
     await setUserName() // set local name refs from auth api fetch result
     await checkAccountStatus() // redirect user if account status is nsf suspended/suspended/pending review
     if (currentAccount.value.id && kcUser.value.keycloakGuid) { // check for pending approvals

--- a/nuxt/layers/core/app/stores/connect-account.ts
+++ b/nuxt/layers/core/app/stores/connect-account.ts
@@ -112,10 +112,10 @@ export const useConnectAccountStore = defineStore('connect-core-account-store', 
     if (user.value?.loginSource === LoginSource.BCEID) {
       // get from auth
       const authUserInfo = await getAuthUserProfile('@me')
-      // firstName and lastName dont always exist it seems ?
-      if (authUserInfo.firstname !== undefined && authUserInfo.lastname !== undefined) {
-        userFirstName.value = authUserInfo.firstname
-        userLastName.value = authUserInfo.lastname
+      // firstName and lastName dont always exist it seems ?, also response isn't camelcase eg. firstname
+      if (authUserInfo.firstName !== undefined && authUserInfo.lastName !== undefined) {
+        userFirstName.value = authUserInfo.firstName
+        userLastName.value = authUserInfo.lastName
       }
       return
     }

--- a/nuxt/layers/core/package.json
+++ b/nuxt/layers/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sbc-connect/nuxt-core-layer-beta",
   "type": "module",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "./nuxt.config.ts",
   "scripts": {
     "dev": "nuxi dev .playground --port 3000",


### PR DESCRIPTION
have Fetch use refactored headers function
Fix isLogin for IDIR, BCSC
Refactor headers into reusable function