### PR TITLE
fix: add setup_pg8000_close_event_listener to python3.9 branch

### DIFF
--- a/python/cloud-sql-connector/pyproject.toml
+++ b/python/cloud-sql-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cloud-sql-connector"
-version = "0.2.2"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 authors = ["Andriy Bolyachevets <andriy.Bolyachevets@gov.bc.ca>"]
 readme = "README.md"

--- a/python/cloud-sql-connector/src/cloud_sql_connector/__init__.py
+++ b/python/cloud-sql-connector/src/cloud_sql_connector/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 """This module provides Cloud SQL connection utilities and database configuration helpers."""
 
-from .connector import DBConfig, getconn, setup_search_path_event_listener
+from .connector import DBConfig, getconn, setup_pg8000_close_event_listener, setup_search_path_event_listener
 
-__all__ = ["DBConfig", "getconn", "setup_search_path_event_listener"]
+__all__ = ["DBConfig", "getconn", "setup_pg8000_close_event_listener", "setup_search_path_event_listener"]

--- a/python/cloud-sql-connector/src/cloud_sql_connector/connector.py
+++ b/python/cloud-sql-connector/src/cloud_sql_connector/connector.py
@@ -134,3 +134,40 @@ def setup_search_path_event_listener(engine, schema: str):
         cursor = dbapi_connection.cursor()
         cursor.execute(f"SET search_path TO {schema}, public")
         cursor.close()
+
+
+# -------------------------------------------------------------------
+# SQLAlchemy event: suppress pg8000 InterfaceError on close
+# -------------------------------------------------------------------
+
+def setup_pg8000_close_event_listener(engine):
+    """
+    Wraps each pg8000 connection's close() to suppress InterfaceError
+    during Cloud Run scale-down when sockets are already severed.
+    """
+    if getattr(engine, "driver", None) != "pg8000":
+        return
+
+    import logging
+
+    try:
+        from pg8000.exceptions import InterfaceError
+    except ImportError:
+        InterfaceError = None
+
+    @event.listens_for(engine, "connect")
+    def on_connect(dbapi_conn, _connection_record):
+        original_close = dbapi_conn.close
+
+        def safe_close():
+            try:
+                original_close()
+            except Exception as e:
+                if InterfaceError and isinstance(e, InterfaceError):
+                    logging.getLogger(__name__).debug(
+                        "Suppressed pg8000 InterfaceError on connection close during teardown."
+                    )
+                else:
+                    raise
+
+        dbapi_conn.close = safe_close


### PR DESCRIPTION
## Summary
- Adds `setup_pg8000_close_event_listener` to the `cloud-sql-connector-python3.9` branch (backport from main)
- Bumps version to `0.2.3`

This function wraps each pg8000 connection's `close()` to suppress `pg8000.exceptions.InterfaceError` during Cloud Run scale-down, when sockets are already severed before the app finishes shutting down.

Required by bcgov/lear#4436 — legal-api uses the python3.9 branch and needs this function available on bcgov so the poetry.lock resolved reference is reachable during CI/Docker builds.