### PR TITLE
port: add pg8000 close event listener to python3.9 branch (PR #71 backport)

### DIFF
--- a/python/cloud-sql-connector/pyproject.toml
+++ b/python/cloud-sql-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cloud-sql-connector"
-version = "0.2.2"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 authors = ["Andriy Bolyachevets <andriy.Bolyachevets@gov.bc.ca>"]
 readme = "README.md"

--- a/python/cloud-sql-connector/src/cloud_sql_connector/__init__.py
+++ b/python/cloud-sql-connector/src/cloud_sql_connector/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 """This module provides Cloud SQL connection utilities and database configuration helpers."""
 
-from .connector import DBConfig, getconn, setup_search_path_event_listener
+from .connector import DBConfig, getconn, setup_pg8000_close_event_listener, setup_search_path_event_listener
 
-__all__ = ["DBConfig", "getconn", "setup_search_path_event_listener"]
+__all__ = ["DBConfig", "getconn", "setup_pg8000_close_event_listener", "setup_search_path_event_listener"]

--- a/python/cloud-sql-connector/src/cloud_sql_connector/connector.py
+++ b/python/cloud-sql-connector/src/cloud_sql_connector/connector.py
@@ -134,3 +134,40 @@ def setup_search_path_event_listener(engine, schema: str):
         cursor = dbapi_connection.cursor()
         cursor.execute(f"SET search_path TO {schema}, public")
         cursor.close()
+
+
+# -------------------------------------------------------------------
+# SQLAlchemy event: suppress pg8000 InterfaceError on close
+# -------------------------------------------------------------------
+
+def setup_pg8000_close_event_listener(engine):
+    """
+    Wraps each pg8000 connection's close() to suppress InterfaceError
+    during Cloud Run scale-down when sockets are already severed.
+    """
+    if getattr(engine, "driver", None) != "pg8000":
+        return
+
+    import logging
+
+    try:
+        from pg8000.exceptions import InterfaceError
+    except ImportError:
+        InterfaceError = None
+
+    @event.listens_for(engine, "connect")
+    def on_connect(dbapi_conn, _connection_record):
+        original_close = dbapi_conn.close
+
+        def safe_close():
+            try:
+                original_close()
+            except Exception as e:
+                if InterfaceError and isinstance(e, InterfaceError):
+                    logging.getLogger(__name__).debug(
+                        "Suppressed pg8000 InterfaceError on connection close during teardown."
+                    )
+                else:
+                    raise
+
+        dbapi_conn.close = safe_close

--- a/python/cloud-sql-connector/tests/unit/test_connector.py
+++ b/python/cloud-sql-connector/tests/unit/test_connector.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 import pytest
 
 from cloud_sql_connector.connector import (DBConfig, getconn,
+                                           setup_pg8000_close_event_listener,
                                            setup_search_path_event_listener)
 
 
@@ -185,3 +186,147 @@ class TestSetupSearchPathEventListener:
             "SET search_path TO test_schema,public"
         )
         mock_cursor.close.assert_called_once()
+
+
+class TestSetupPg8000CloseEventListener:
+    """Test the setup_pg8000_close_event_listener function."""
+
+    @patch("cloud_sql_connector.connector.event")
+    def test_setup_pg8000_close_event_listener_non_pg8000(self, mock_event):
+        """Test setting up the event listener skips when driver is not pg8000."""
+        mock_engine = Mock()
+        mock_engine.driver = "psycopg2"
+
+        # Call function
+        setup_pg8000_close_event_listener(mock_engine)
+
+        # Verify event listener is NOT set up
+        mock_event.listens_for.assert_not_called()
+
+    @patch("cloud_sql_connector.connector.event")
+    def test_setup_pg8000_close_event_listener(self, mock_event):
+        """Test setting up the pg8000 close event listener."""
+        mock_engine = Mock()
+        mock_engine.driver = "pg8000"
+
+        # Call function
+        setup_pg8000_close_event_listener(mock_engine)
+
+        # Verify event listener is set up
+        mock_event.listens_for.assert_called_once_with(mock_engine, "connect")
+
+    @patch("cloud_sql_connector.connector.event")
+    def test_event_listener_callback_normal_close(self, mock_event):
+        """Test the event listener callback function with normal close."""
+        mock_engine = Mock()
+        mock_engine.driver = "pg8000"
+
+        # Capture the callback function
+        callback_function = None
+
+        def capture_callback(engine, event_name):
+            def decorator(func):
+                nonlocal callback_function
+                callback_function = func
+                return func
+
+            return decorator
+
+        mock_event.listens_for.side_effect = capture_callback
+
+        # Setup the event listener
+        setup_pg8000_close_event_listener(mock_engine)
+
+        # Test the callback
+        mock_dbapi_conn = Mock()
+        original_close = mock_dbapi_conn.close
+        mock_connection_record = Mock()
+
+        # Call the callback to setup the wrapper
+        callback_function(mock_dbapi_conn, mock_connection_record)
+
+        # Now mock_dbapi_conn.close should be the wrapped safe_close
+        mock_dbapi_conn.close()
+
+        # original_close should have been called
+        original_close.assert_called_once()
+
+    @patch("cloud_sql_connector.connector.event")
+    def test_event_listener_callback_interface_error(self, mock_event):
+        """Test the event listener callback function suppressing InterfaceError."""
+        mock_engine = Mock()
+        mock_engine.driver = "pg8000"
+
+        # Capture the callback function
+        callback_function = None
+
+        def capture_callback(engine, event_name):
+            def decorator(func):
+                nonlocal callback_function
+                callback_function = func
+                return func
+
+            return decorator
+
+        mock_event.listens_for.side_effect = capture_callback
+
+        # Setup the event listener
+        setup_pg8000_close_event_listener(mock_engine)
+
+        # Mock the dbapi_conn and its close method to raise InterfaceError
+        try:
+            from pg8000.exceptions import InterfaceError
+        except ImportError:
+            InterfaceError = Exception
+
+        mock_dbapi_conn = Mock()
+        original_close = Mock(side_effect=InterfaceError("Test InterfaceError"))
+        mock_dbapi_conn.close = original_close
+        mock_connection_record = Mock()
+
+        # Call the callback to setup the wrapper
+        callback_function(mock_dbapi_conn, mock_connection_record)
+
+        # Now mock_dbapi_conn.close should be the wrapped safe_close
+        # This shouldn't raise any exception
+        mock_dbapi_conn.close()
+
+        # original_close should have been called
+        original_close.assert_called_once()
+
+    @patch("cloud_sql_connector.connector.event")
+    def test_event_listener_callback_other_error(self, mock_event):
+        """Test the event listener callback function re-raises other errors."""
+        mock_engine = Mock()
+        mock_engine.driver = "pg8000"
+        callback_function = None
+
+        def capture_callback(engine, event_name):
+            def decorator(func):
+                nonlocal callback_function
+                callback_function = func
+                return func
+
+            return decorator
+
+        mock_event.listens_for.side_effect = capture_callback
+
+        # Setup the event listener
+        setup_pg8000_close_event_listener(mock_engine)
+
+        # Mock the dbapi_conn and its close method to raise ValueError
+        mock_dbapi_conn = Mock()
+        original_close = Mock(side_effect=ValueError("Some other error"))
+        mock_dbapi_conn.close = original_close
+        mock_connection_record = Mock()
+
+        # Call the callback to setup the wrapper
+        callback_function(mock_dbapi_conn, mock_connection_record)
+
+        # Now mock_dbapi_conn.close should be the wrapped safe_close
+        # This SHOULD raise the exception
+        with pytest.raises(ValueError, match="Some other error"):
+            mock_dbapi_conn.close()
+
+        # original_close should have been called
+        original_close.assert_called_once()


### PR DESCRIPTION
## Summary

- Backports the `setup_pg8000_close_event_listener` function from [PR #71](https://github.com/bcgov/sbc-connect-common/pull/71) into the `cloud-sql-connector-python3.9` branch
- Bumps package version to `0.2.3` in `pyproject.toml`
- Exports `setup_pg8000_close_event_listener` via `__init__.py`
- Ports the full `TestSetupPg8000CloseEventListener` test class (5 tests) to `test_connector.py`

## Notes

- `close_connector` is intentionally **not** imported/exported — it does not exist in the python3.9-compatible `connector.py`
- The `setup_pg8000_close_event_listener` implementation includes an extra guard (`if getattr(engine, "driver", None) != "pg8000": return`) that was added in the final commit of PR #71

## Test plan

- [ ] Verify `TestSetupPg8000CloseEventListener` tests pass in the python3.9 environment
- [ ] Confirm no regressions in existing `TestDBConfig`, `TestGetconn`, and `TestSetupSearchPathEventListener` tests
