### PR TITLE
feat(cloud-sql): centralize environment settings

### DIFF
--- a/python/cloud-sql-connector/src/cloud_sql_connector/__init__.py
+++ b/python/cloud-sql-connector/src/cloud_sql_connector/__init__.py
@@ -16,7 +16,9 @@
 from .connector import (
     DBConfig,
     close_connector,
+    database_uri_from_env,
     getconn,
+    sqlalchemy_settings_from_env,
     setup_pg8000_close_event_listener,
     setup_search_path_event_listener,
 )
@@ -24,7 +26,9 @@ from .connector import (
 __all__ = [
     "DBConfig",
     "close_connector",
+    "database_uri_from_env",
     "getconn",
+    "sqlalchemy_settings_from_env",
     "setup_pg8000_close_event_listener",
     "setup_search_path_event_listener",
 ]

--- a/python/cloud-sql-connector/src/cloud_sql_connector/connector.py
+++ b/python/cloud-sql-connector/src/cloud_sql_connector/connector.py
@@ -13,15 +13,22 @@
 # limitations under the License.
 """Cloud SQL connection utilities for the Notify API service."""
 
+import os
 import threading
 import time
 from dataclasses import dataclass
+from typing import Mapping
 
 from google.cloud.sql.connector import Connector
 from sqlalchemy import event
 
 _connector = None
 _lock = threading.Lock()
+_CLOUDSQL_REQUIRED_ENV_VARS = (
+    "CLOUDSQL_INSTANCE_CONNECTION_NAME",
+    "DATABASE_NAME",
+    "DATABASE_USERNAME",
+)
 
 
 @dataclass
@@ -66,6 +73,69 @@ class DBConfig:
             "pool_use_lifo": self.pool_use_lifo,
             "connect_args": self.connect_args,
         }
+
+
+def database_uri_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    username_env: str = "DATABASE_USERNAME",
+    password_env: str = "DATABASE_PASSWORD",
+    name_env: str = "DATABASE_NAME",
+    host_env: str = "DATABASE_HOST",
+    port_env: str = "DATABASE_PORT",
+) -> str:
+    """Build a local pg8000 SQLAlchemy URI from environment variables."""
+    values = env if env is not None else os.environ
+    db_user = values.get(username_env, "")
+    db_password = values.get(password_env, "")
+    db_name = values.get(name_env, "")
+    db_host = values.get(host_env, "")
+    db_port = values.get(port_env, "5432")
+
+    if db_unix_socket := values.get("DATABASE_UNIX_SOCKET"):
+        return (
+            f"postgresql+pg8000://{db_user}:{db_password}@/{db_name}"
+            f"?unix_sock={db_unix_socket}/.s.PGSQL.5432"
+        )
+
+    return (
+        f"postgresql+pg8000://{db_user}:{db_password}@" f"{db_host}:{db_port}/{db_name}"
+    )
+
+
+def sqlalchemy_settings_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    schema: str = "",
+) -> tuple[str, dict]:
+    """Build SQLAlchemy URI and engine options for local or Cloud SQL IAM use."""
+    values = env if env is not None else os.environ
+    use_cloudsql_iam = bool(
+        values.get("CLOUDSQL_INSTANCE_CONNECTION_NAME")
+        or values.get("K_SERVICE")
+        or values.get("CLOUD_RUN_JOB")
+    )
+    if not use_cloudsql_iam:
+        return database_uri_from_env(values), {}
+
+    missing = [name for name in _CLOUDSQL_REQUIRED_ENV_VARS if not values.get(name)]
+    if missing:
+        raise RuntimeError(
+            f"Missing Cloud SQL IAM environment variables: {', '.join(missing)}"
+        )
+
+    ip_type = values.get("CLOUDSQL_IP_TYPE", "PUBLIC").upper()
+    if ip_type not in ("PUBLIC", "PRIVATE"):
+        raise RuntimeError("CLOUDSQL_IP_TYPE must be PUBLIC or PRIVATE")
+
+    config = DBConfig(
+        instance_name=values["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
+        database=values["DATABASE_NAME"],
+        user=values["DATABASE_USERNAME"],
+        ip_type=ip_type,
+        schema=schema,
+    )
+    return "postgresql+pg8000://", {"creator": lambda: getconn(config)}
 
 
 def _get_connector() -> Connector:

--- a/python/cloud-sql-connector/tests/unit/test_connector.py
+++ b/python/cloud-sql-connector/tests/unit/test_connector.py
@@ -21,7 +21,9 @@ import pytest
 from cloud_sql_connector.connector import (
     DBConfig,
     close_connector,
+    database_uri_from_env,
     getconn,
+    sqlalchemy_settings_from_env,
     setup_pg8000_close_event_listener,
     setup_search_path_event_listener,
 )
@@ -57,6 +59,102 @@ class TestDBConfig:
         )
 
         assert config.schema == ""
+
+
+class TestEnvironmentSettings:
+    """Test SQLAlchemy configuration derived from environment values."""
+
+    def test_database_uri(self):
+        """Build a TCP URI for local development."""
+        uri = database_uri_from_env(
+            {
+                "DATABASE_USERNAME": "user",
+                "DATABASE_PASSWORD": "password",
+                "DATABASE_NAME": "database",
+                "DATABASE_HOST": "localhost",
+                "DATABASE_PORT": "5433",
+            }
+        )
+
+        assert uri == "postgresql+pg8000://user:password@localhost:5433/database"
+
+    def test_database_uri_with_unix_socket(self):
+        """Build a Unix socket URI when configured."""
+        uri = database_uri_from_env(
+            {
+                "DATABASE_USERNAME": "user",
+                "DATABASE_PASSWORD": "password",
+                "DATABASE_NAME": "database",
+                "DATABASE_UNIX_SOCKET": "/cloudsql/instance",
+            }
+        )
+
+        assert (
+            uri == "postgresql+pg8000://user:password@/database"
+            "?unix_sock=/cloudsql/instance/.s.PGSQL.5432"
+        )
+
+    def test_local_sqlalchemy_settings(self):
+        """Use a standard URI and no engine options locally."""
+        uri, engine_options = sqlalchemy_settings_from_env(
+            {
+                "DATABASE_USERNAME": "user",
+                "DATABASE_PASSWORD": "password",
+                "DATABASE_NAME": "database",
+                "DATABASE_HOST": "localhost",
+            }
+        )
+
+        assert uri == "postgresql+pg8000://user:password@localhost:5432/database"
+        assert engine_options == {}
+
+    @patch("cloud_sql_connector.connector.getconn")
+    def test_cloud_sqlalchemy_settings(self, mock_getconn):
+        """Use a connection creator for deployed Cloud SQL IAM access."""
+        uri, engine_options = sqlalchemy_settings_from_env(
+            {
+                "K_SERVICE": "service",
+                "CLOUDSQL_INSTANCE_CONNECTION_NAME": "project:region:instance",
+                "DATABASE_NAME": "database",
+                "DATABASE_USERNAME": "service-account",
+                "CLOUDSQL_IP_TYPE": "private",
+            }
+        )
+
+        assert uri == "postgresql+pg8000://"
+        engine_options["creator"]()
+        assert mock_getconn.call_args.args[0] == DBConfig(
+            instance_name="project:region:instance",
+            database="database",
+            user="service-account",
+            ip_type="PRIVATE",
+            schema="",
+        )
+
+    def test_cloud_sqlalchemy_settings_require_values(self):
+        """Report every required Cloud SQL IAM value that is absent."""
+        with pytest.raises(
+            RuntimeError,
+            match=(
+                "Missing Cloud SQL IAM environment variables: "
+                "CLOUDSQL_INSTANCE_CONNECTION_NAME, DATABASE_NAME, DATABASE_USERNAME"
+            ),
+        ):
+            sqlalchemy_settings_from_env({"K_SERVICE": "service"})
+
+    def test_cloud_sqlalchemy_settings_validate_ip_type(self):
+        """Reject connector IP types other than public and private."""
+        with pytest.raises(
+            RuntimeError, match="CLOUDSQL_IP_TYPE must be PUBLIC or PRIVATE"
+        ):
+            sqlalchemy_settings_from_env(
+                {
+                    "CLOUDSQL_INSTANCE_CONNECTION_NAME": "project:region:instance",
+                    "DATABASE_NAME": "database",
+                    "DATABASE_USERNAME": "service-account",
+                    "CLOUDSQL_IP_TYPE": "invalid",
+                }
+            )
 
 
 class TestGetconn:


### PR DESCRIPTION
## Summary
- add shared helpers for local database URIs and Cloud SQL IAM SQLAlchemy settings
- validate required IAM environment values and IP type in one place
- add focused unit coverage for local, Unix socket, and deployed configurations

## Testing
- `poetry run pytest tests/unit -q` (19 passed)

Supports bcgov/STRR#1764 by removing duplicated connection configuration from STRR jobs and queue services.